### PR TITLE
texstudio-beta: fix missing Linux stanzas

### DIFF
--- a/Casks/texstudio-beta.rb
+++ b/Casks/texstudio-beta.rb
@@ -42,7 +42,7 @@ cask "texstudio-beta" do
   # learnt from https://github.com/Homebrew/homebrew-cask/blob/03a0edb4616198f6f64b285dbf842bc3b73a7f31/Casks/p/parallels.rb#L36-L41
   postflight do
     system_command "xattr",
-                    args: ["-dr", "com.apple.quarantine", "#{appdir}/texstudio-#{version}-osx#{arch}.app"]
+                   args: ["-dr", "com.apple.quarantine", "#{appdir}/texstudio-#{version}-osx#{arch}.app"]
   end
 
   zap trash: [

--- a/Casks/texstudio-beta.rb
+++ b/Casks/texstudio-beta.rb
@@ -1,57 +1,53 @@
 cask "texstudio-beta" do
-  # work around https://github.com/Homebrew/homebrew-cask/issues/205491
-  # see also https://github.com/orgs/Homebrew/discussions/6008#discussioncomment-12440672
-  on_macos do
-    arch arm: "-m1"
+  arch arm: "-m1"
 
-    version "4.9.7alpha1"
-    sha256 arm:   "e976efcb3e7ca35ad57b07fdd0bb365ca7626f5003f8ce1ab1f410290b1a5d83",
-           intel: "4615aff069e08a8437a65d1fe74608c5c747d0d22fafa732903406c3eb5f099f"
+  version "4.9.7alpha1"
+  sha256 arm:   "e976efcb3e7ca35ad57b07fdd0bb365ca7626f5003f8ce1ab1f410290b1a5d83",
+         intel: "4615aff069e08a8437a65d1fe74608c5c747d0d22fafa732903406c3eb5f099f"
 
-    url "https://github.com/texstudio-org/texstudio/releases/download/#{version}/texstudio-#{version}-osx#{arch}.zip",
-        verified: "github.com/texstudio-org/texstudio/"
-    name "TeXstudio"
-    desc "Fully featured LaTeX editor, beta version"
-    homepage "https://texstudio.org/"
+  url "https://github.com/texstudio-org/texstudio/releases/download/#{version}/texstudio-#{version}-osx#{arch}.zip",
+      verified: "github.com/texstudio-org/texstudio/"
+  name "TeXstudio"
+  desc "Fully featured LaTeX editor, beta version"
+  homepage "https://texstudio.org/"
 
-    livecheck do
-      # based on https://docs.brew.sh/Brew-Livecheck#githubreleases-strategy-block
-      url :url
-      regex(/^v?(\d+(?:\.\d+)+(?:(?:alpha|beta|rc)\d+)?)$/i)
-      strategy :github_releases do |json, regex|
-        json.map do |release|
-          next if release["draft"]
+  livecheck do
+    # based on https://docs.brew.sh/Brew-Livecheck#githubreleases-strategy-block
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+(?:(?:alpha|beta|rc)\d+)?)$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"]
 
-          match = release["tag_name"]&.match(regex)
-          next if match.blank?
+        match = release["tag_name"]&.match(regex)
+        next if match.blank?
 
-          match[1]
-        end
+        match[1]
       end
-      # :page_match can just list pre-releases
-      # learnt from https://github.com/Homebrew/homebrew-cask-versions/blob/948fe36253038658716087daac8c4b1f0ae0f7c3/Casks/utm-beta.rb#L11-L15
-      #   url "https://github.com/texstudio-org/texstudio/releases?q=prerelease%3Atrue&expanded=true"
-      #   regex(%r{href=["']?[^"' >]*?/tag/v?(\d+(?:\.\d+)+[^"' >]*)["' >]}i)
-      #   strategy :page_match
     end
-
-    conflicts_with cask: "texstudio"
-    depends_on macos: :ventura
-
-    # it's NOT recommended to rename the target only for removing version numbers
-    # https://docs.brew.sh/Cask-Cookbook#target-should-only-be-used-in-select-cases
-    app "texstudio-#{version}-osx#{arch}.app"
-
-    # learnt from https://github.com/Homebrew/homebrew-cask/blob/03a0edb4616198f6f64b285dbf842bc3b73a7f31/Casks/p/parallels.rb#L36-L41
-    postflight do
-      system_command "xattr",
-                     args: ["-dr", "com.apple.quarantine", "#{appdir}/texstudio-#{version}-osx#{arch}.app"]
-    end
-
-    zap trash: [
-      "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/texstudio.sfl*",
-      "~/Library/Preferences/texstudio.plist",
-      "~/Library/Saved Application State/texstudio.savedState",
-    ]
+    # :page_match can just list pre-releases
+    # learnt from https://github.com/Homebrew/homebrew-cask-versions/blob/948fe36253038658716087daac8c4b1f0ae0f7c3/Casks/utm-beta.rb#L11-L15
+    #   url "https://github.com/texstudio-org/texstudio/releases?q=prerelease%3Atrue&expanded=true"
+    #   regex(%r{href=["']?[^"' >]*?/tag/v?(\d+(?:\.\d+)+[^"' >]*)["' >]}i)
+    #   strategy :page_match
   end
+
+  conflicts_with cask: "texstudio"
+  depends_on macos: :ventura
+
+  # it's NOT recommended to rename the target only for removing version numbers
+  # https://docs.brew.sh/Cask-Cookbook#target-should-only-be-used-in-select-cases
+  app "texstudio-#{version}-osx#{arch}.app"
+
+  # learnt from https://github.com/Homebrew/homebrew-cask/blob/03a0edb4616198f6f64b285dbf842bc3b73a7f31/Casks/p/parallels.rb#L36-L41
+  postflight do
+    system_command "xattr",
+                    args: ["-dr", "com.apple.quarantine", "#{appdir}/texstudio-#{version}-osx#{arch}.app"]
+  end
+
+  zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/texstudio.sfl*",
+    "~/Library/Preferences/texstudio.plist",
+    "~/Library/Saved Application State/texstudio.savedState",
+  ]
 end


### PR DESCRIPTION
This basically reverts the workaround in
b8b93fa (texstudio-beta: fix linux CI, 3rd attempt, 2025-04-09)